### PR TITLE
Timur/waiter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(crill)
 
 include_directories(include)
 
-add_executable(tests tests/main.cpp tests/spin_mutex_test.cpp)
+add_executable(tests tests/main.cpp tests/spin_mutex_test.cpp tests/wait_test.cpp)
 target_compile_features(tests PRIVATE cxx_std_17)
 
 # Avoid "undefined reference to 'pthread_create'" linker error on Linux

--- a/include/crill/impl/wait_platform_specific.h
+++ b/include/crill/impl/wait_platform_specific.h
@@ -1,0 +1,90 @@
+// crill - the Cross-platform Real-time, I/O, and Low-Latency Library
+// Copyright (c) 2022 - Timur Doumler and Fabian Renn-Giles
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#ifndef CRILL_WAIT_PLATFORM_SPECIFIC_H
+#define CRILL_WAIT_PLATFORM_SPECIFIC_H
+
+#include <thread>
+
+#if CRILL_INTEL
+  #include <emmintrin.h>
+#elif CRILL_ARM_64BIT
+  #include <arm_acle.h>
+#endif
+
+namespace crill::impl
+{
+  #if CRILL_INTEL
+    template <std::size_t N0, std::size_t N1, std::size_t N2, typename Predicate>
+    void progressive_backoff_wait_intel(Predicate&& pred)
+    {
+        for (int i = 0; i < N0; ++i)
+        {
+            if (pred())
+                return;
+        }
+
+        for (int i = 0; i < N1; ++i)
+        {
+            if (pred())
+                return;
+
+            _mm_pause();
+        }
+
+        while (true)
+        {
+            for (int i = 0; i < N2; ++i)
+            {
+                if (pred())
+                    return;
+
+                // Do not roll these into a loop: not every compiler unrolls it
+                _mm_pause();
+                _mm_pause();
+                _mm_pause();
+                _mm_pause();
+                _mm_pause();
+                _mm_pause();
+                _mm_pause();
+                _mm_pause();
+                _mm_pause();
+                _mm_pause();
+            }
+
+            // waiting longer than we should, let's give other threads a chance to recover
+            std::this_thread::yield();
+        }
+    }
+  #endif // CRILL_INTEL
+
+  #if CRILL_ARM_64BIT
+    template <std::size_t N0, std::size_t N1, typename Predicate>
+    void progressive_backoff_wait_armv8(Predicate&& pred)
+    {
+        for (int i = 0; i < N0; ++i)
+        {
+            if (pred())
+                return;
+        }
+
+        while (true)
+        {
+            for (int i = 0; i < N1; ++i)
+            {
+                if (pred())
+                    return;
+
+                __wfe();
+            }
+
+            // waiting longer than we should, let's give other threads a chance to recover
+            std::this_thread::yield();
+        }
+    }
+  #endif // CRILL_ARM_64BIT
+} // namespace crill::impl
+
+#endif //CRILL_WAIT_PLATFORM_SPECIFIC_H

--- a/include/crill/spin_mutex.h
+++ b/include/crill/spin_mutex.h
@@ -6,16 +6,9 @@
 #ifndef CRILL_SPIN_MUTEX_H
 #define CRILL_SPIN_MUTEX_H
 
-#include <crill/platform.h>
 #include <atomic>
-#include <thread>
 #include <mutex>
-
-#if CRILL_INTEL
-  #include <emmintrin.h>
-#elif CRILL_ARM_64BIT
-  #include <arm_acle.h>
-#endif
+#include <crill/wait.h>
 
 namespace crill
 {
@@ -32,16 +25,8 @@ namespace crill
 // which doesn't have a wait-free unlock() as std::mutex::unlock() may perform
 // a system call to wake up a waiting thread.
 //
-// On Intel as well as 64-bit ARM, lock() is implemented using a progressive
-// back-off strategy, rather than just spin (busy-wait) like in a naive spinlock,
-// to prevent wasting energy and allow other threads to progress.
-// The parameters of the progressive back-off are tuned for the scenario in a
-// typical audio app (real-time thread is being called on a callback every 1-10 ms)
-// but are useful for other scenarios as well.
-//
-// On platforms other than Intel and 64-bit ARM, progressive backoff is currently
-// not implemented and lock() uses a naive fallback implementation that just spins
-// (busy-waits).
+// lock() is implemented with crill::progressive_backoff_wait, to prevent wasting
+// energy and allow other threads to progress.
 //
 // crill::spin_mutex is not recursive; repeatedly locking it on the same thread
 // is undefined behaviour (in practice, it will probably deadlock your app).
@@ -52,17 +37,7 @@ public:
     // Preconditions: The current thread does not already hold the lock.
     void lock() noexcept
     {
-      #if CRILL_INTEL
-        lock_impl_intel<5, 10, 3000>();
-        // approx. 5x5 ns (= 25 ns), 10x40 ns (= 400 ns), and 3000x350 ns (~ 1 ms),
-        // respectively, when measured on a 2.9 GHz Intel i9
-      #elif CRILL_ARM_64BIT
-        lock_impl_armv8<2, 750>();
-        // approx. 2x10 ns (= 20 ns) and 750x1333 ns (~ 1 ms), respectively, on an
-        // Apple Silicon Mac or an armv8 based phone.
-      #else
-        lock_impl_no_progressive_backoff();
-      #endif
+        progressive_backoff_wait([this]{ return try_lock(); });
     }
 
     // Effects: Attempts to acquire the lock without blocking.
@@ -83,81 +58,6 @@ public:
 
 private:
     std::atomic_flag flag = ATOMIC_FLAG_INIT;
-
-  #if CRILL_INTEL
-    template <std::size_t N0, std::size_t N1, std::size_t N2>
-    void lock_impl_intel()
-    {
-        for (int i = 0; i < N0; ++i)
-        {
-            if (try_lock())
-                return;
-        }
-
-        for (int i = 0; i < N1; ++i)
-        {
-            if (try_lock())
-                return;
-
-            _mm_pause();
-        }
-
-        while (true)
-        {
-            for (int i = 0; i < N2; ++i)
-            {
-                if (try_lock())
-                    return;
-
-                // Do not roll these into a loop: not every compiler unrolls it
-                _mm_pause();
-                _mm_pause();
-                _mm_pause();
-                _mm_pause();
-                _mm_pause();
-                _mm_pause();
-                _mm_pause();
-                _mm_pause();
-                _mm_pause();
-                _mm_pause();
-            }
-
-            // waiting longer than we should, let's give other threads a chance to recover
-            std::this_thread::yield();
-        }
-    }
-  #elif CRILL_ARM_64BIT
-    template <std::size_t N0, std::size_t N1>
-    void lock_impl_armv8() noexcept
-    {
-        for (int i = 0; i < N0; ++i)
-        {
-            if (try_lock())
-                return;
-        }
-
-        while (true)
-        {
-            for (int i = 0; i < N1; ++i)
-            {
-                if (try_lock())
-                    return;
-
-                __wfe();
-            }
-
-            // waiting longer than we should, let's give other threads a chance to recover
-            std::this_thread::yield();
-        }
-    }
-  #else
-    // fallback for unsupported platforms
-    void lock_impl_no_progressive_backoff() noexcept
-    {
-        while (!try_lock())
-            /* spin */;
-    }
-  #endif
 };
 
 } // namespace crill

--- a/include/crill/wait.h
+++ b/include/crill/wait.h
@@ -1,0 +1,49 @@
+// crill - the Cross-platform Real-time, I/O, and Low-Latency Library
+// Copyright (c) 2022 - Timur Doumler and Fabian Renn-Giles
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#ifndef CRILL_WAITER_H
+#define CRILL_WAITER_H
+
+#include <crill/platform.h>
+#include <crill/impl/wait_platform_specific.h>
+
+namespace crill {
+
+// Effects: Blocks the current thread until predicate returns true. Blocking is
+// implemented by spinning on the predicate with a progressive backoff strategy.
+//
+// crill::progressive_backoff_wait is used to implement crill::spin_mutex, but is also
+// useful on its own, in scenarios where a thread needs to wait on something else
+// than a spinlock being released (for example, a CAS loop).
+//
+// Compared to a naive implementation like
+//
+//    while (!predicate()) /* spin */;
+//
+// the progressive backoff strategy prevents wasting energy, and allows other threads
+// to progress by yielding from the waiting thread after a certain amount of time.
+// This time is currently chosen to be approximately 1 ms on a typical 64-bit Intel
+// or ARM based machine.
+//
+// On platforms other than x86, x86_64, and arm64, no implementation is currently available.
+template <typename Predicate>
+void progressive_backoff_wait(Predicate&& pred)
+{
+  #if CRILL_INTEL
+    impl::progressive_backoff_wait_intel<5, 10, 3000>(std::forward<Predicate>(pred));
+    // approx. 5x5 ns (= 25 ns), 10x40 ns (= 400 ns), and 3000x350 ns (~ 1 ms),
+    // respectively, when measured on a 2.9 GHz Intel i9
+  #elif CRILL_ARM_64BIT
+    impl::progressive_backoff_wait_armv8<2, 750>(std::forward<Predicate>(pred));
+    // approx. 2x10 ns (= 20 ns) and 750x1333 ns (~ 1 ms), respectively, on an
+    // Apple Silicon Mac or an armv8 based phone.
+  #else
+    #error "Platform not supported!"
+  #endif
+}
+
+#endif //CRILL_WAITER_H
+
+} // namespace crill

--- a/tests/spin_mutex_test.cpp
+++ b/tests/spin_mutex_test.cpp
@@ -3,27 +3,18 @@
 // Distributed under the Boost Software License, Version 1.0.
 //(See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
-#include <doctest/doctest.h>
 #include <crill/spin_mutex.h>
-
-// Helper for doctest static tests:
-// (see https://github.com/doctest/doctest/issues/250)
-// TODO: put this into a header common to all tests?
-#define STATIC_CHECK(...) static_assert(__VA_ARGS__); CHECK(__VA_ARGS__);
-#define STATIC_CHECK_FALSE(...) static_assert(!__VA_ARGS__); CHECK_FALSE(__VA_ARGS__);
+#include <doctest/doctest.h>
 
 TEST_CASE("crill::spin_mutex")
 {
-    crill::spin_mutex mtx;
+    static_assert(std::is_default_constructible_v<crill::spin_mutex>);
+    static_assert(!std::is_copy_constructible_v<crill::spin_mutex>);
+    static_assert(!std::is_copy_assignable_v<crill::spin_mutex>);
+    static_assert(!std::is_move_constructible_v<crill::spin_mutex>);
+    static_assert(!std::is_move_assignable_v<crill::spin_mutex>);
 
-    SUBCASE("Special member functions")
-    {
-        STATIC_CHECK(std::is_default_constructible_v<crill::spin_mutex>);
-        STATIC_CHECK_FALSE(std::is_copy_constructible_v<crill::spin_mutex>);
-        STATIC_CHECK_FALSE(std::is_copy_assignable_v<crill::spin_mutex>);
-        STATIC_CHECK_FALSE(std::is_move_constructible_v<crill::spin_mutex>);
-        STATIC_CHECK_FALSE(std::is_move_assignable_v<crill::spin_mutex>);
-    }
+    crill::spin_mutex mtx;
 
     SUBCASE("If mutex is not locked, try_lock succeeds")
     {

--- a/tests/wait_test.cpp
+++ b/tests/wait_test.cpp
@@ -1,0 +1,35 @@
+// crill - the Cross-platform Real-time, I/O, and Low-Latency Library
+// Copyright (c) 2022 - Timur Doumler and Fabian Renn-Giles
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#include <atomic>
+#include <thread>
+#include <crill/wait.h>
+#include <doctest/doctest.h>
+
+TEST_CASE("Waiting on a true predicate immediately returns")
+{
+    crill::progressive_backoff_wait([]{ return true; });
+}
+
+TEST_CASE("Waiting on a false predicate blocks until predicate becomes true")
+{
+    std::atomic<bool> flag = false;
+    std::atomic<bool> waiter_thread_running = false;
+    std::atomic<bool> waiter_thread_done = false;
+    std::thread waiter_thread([&]{
+        waiter_thread_running = true;
+        crill::progressive_backoff_wait([&]{ return flag == true; });
+        waiter_thread_done = true;
+    });
+
+    while (!waiter_thread_running)
+        /* wait for thread to start*/;
+
+    REQUIRE_FALSE(waiter_thread_done);
+
+    flag = true;
+    waiter_thread.join();
+    REQUIRE(waiter_thread_done);
+}


### PR DESCRIPTION
Factored out logic for progressive backoff waiting from crill::spin_mitex into a generic free-standing function crill::progressive_backoff_wait, so it can be used to wait on something else than a spinlock being released (for example, a CAS loop).