### PR TITLE
Add windows/arm64 support, ensure unsupported platforms see a compile error

### DIFF
--- a/include/crill/bytewise_atomic_memcpy.h
+++ b/include/crill/bytewise_atomic_memcpy.h
@@ -42,11 +42,12 @@ namespace crill {
 
         for (std::size_t i = 0; i < count; ++i) {
               #if __cpp_lib_atomic_ref
-                dest_bytes[i] = std::atomic_ref<char>(src_bytes[i]).load(std::memory_order_relaxed);
+                dest_bytes[i] = std::atomic_ref<const char>(src_bytes[i]).load(std::memory_order_relaxed);
               #elif CRILL_CLANG || CRILL_GCC
                 dest_bytes[i] = __atomic_load_n(src_bytes + i, __ATOMIC_RELAXED);
               #else
                 // No atomic_ref or equivalent functionality available on this platform!
+                #error "Platform not supported!"
               #endif
         }
 
@@ -81,6 +82,7 @@ namespace crill {
             __atomic_store_n(dest_bytes + i, src_bytes[i], __ATOMIC_RELAXED);
           #else
             // No atomic_ref or equivalent functionality available on this platform!
+            #error "Platform not supported!"
           #endif
         }
 

--- a/include/crill/impl/progressive_backoff_wait_impl.h
+++ b/include/crill/impl/progressive_backoff_wait_impl.h
@@ -11,7 +11,11 @@
 #if CRILL_INTEL
   #include <emmintrin.h>
 #elif CRILL_ARM_64BIT
-  #include <arm_acle.h>
+  #ifdef _WIN32
+    #include <intrin.h>
+  #else
+    #include <arm_acle.h>
+  #endif
 #endif
 
 namespace crill::impl

--- a/include/crill/platform.h
+++ b/include/crill/platform.h
@@ -11,7 +11,7 @@
   #define CRILL_ARM 1
   #define CRILL_32BIT 1
   #define CRILL_ARM_32BIT 1
-#elif defined (__arm64__)
+#elif defined (__arm64__) || defined (_M_ARM64)
   #define CRILL_ARM 1
   #define CRILL_64BIT 1
   #define CRILL_ARM_64BIT 1


### PR DESCRIPTION
I've added some updates to support building on windows/arm64.

The tests were previously failing as it was passing through an empty implementation for the memcpy functions, so i've altered these to give a compile error if this happens.

On windows with C++20 enabled, the tests pass on both x64 and arm64 (going via the __cpp_lib_atomic_ref codepath)